### PR TITLE
Pin webpack dependency to 2.1.0-beta.22

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,7 @@
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.4",
     "vue-loader": "^9.2.2",
-    "webpack": "^2.1.0-beta.20",
+    "webpack": "2.1.0-beta.22",
     "webpack-dev-server": "^2.1.0-beta.0"
   }
 }


### PR DESCRIPTION
Webpack 2.1.0-beta.23 introduces breaking changes that cause both `npm run dev` and `npm run build` to fail with the following error:
`Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.`

`webpack-simple` will likely adapt to these changes and fix the error, but this provides a stop-gap for new users until that fix arrives.