### PR TITLE
use root path for build.js so deep links work during dev

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="dist/build.js"></script>
+    <script src="/dist/build.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This should make things a little more useful for people playing with the router as well.