### PR TITLE
NODE_ENV=development in dev mode

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
   "author": "{{ author }}",
   "private": true,
   "scripts": {
-    "dev": "webpack-dev-server --open --inline --hot",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --inline --hot",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {


### PR DESCRIPTION
When executing 'npm run dev' after 'npm run build' the value of NODE_ENV will be 'production'. This causes minification in dev mode which isn't wanted. This change fixes the issue.