### PR TITLE
Set default dev port to 3000

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
   "author": "{{ author }}",
   "private": true,
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --inline --hot",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --port 3000 --open --inline --hot",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {


### PR DESCRIPTION
To address the same issue here: https://github.com/webpack/react-starter/issues/34

The default port for webpack-dev-server is 8080, which could be in use most of the times. When running `npm run dev` without this option, it doesn't run the server, due to an unhandled error in `events.js` (which is related to webpac-dev-server). With `--port 3000` argument, the server runs without any problems in development environments.