### PR TITLE
explicitly add '-loader' to the name of webpack's loader package

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -12,19 +12,19 @@ module.exports = {
     rules: [
       {
         test: /\.vue$/,
-        loader: 'vue',
+        loader: 'vue-loader',
         options: {
           // vue-loader options go here
         }
       },
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'babel-loader',
         exclude: /node_modules/
       },
       {
         test: /\.(png|jpg|gif|svg)$/,
-        loader: 'file',
+        loader: 'file-loader',
         options: {
           name: '[name].[ext]?[hash]'
         }


### PR DESCRIPTION
webpack no longer add `-loader` automatically since 2.1.10@beta.26 version.