### PR TITLE
Add default version to package.json

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -1,6 +1,7 @@
 {
   "name": "{{ name }}",
   "description": "{{ description }}",
+  "version": "1.0.0",
   "author": "{{ author }}",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Not having a version in package.json results in npm prompt errors
```
/npm_prompt.lua:11: attempt to concatenate local 'package_version' (a nil value)
```