### PR TITLE
update webpack cfg to support SASS and SCSS

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -14,6 +14,10 @@ module.exports = {
         test: /\.vue$/,
         loader: 'vue-loader',
         options: {
+          loaders: {
+            'scss': 'vue-style-loader!css-loader!sass-loader',
+            'sass': 'vue-style-loader!css-loader!sass-loader?indentedSytax'
+          }
           // vue-loader options go here
         }
       },

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -15,10 +15,13 @@ module.exports = {
         loader: 'vue-loader',
         options: {
           loaders: {
+            // Since sass-loader (weirdly) has SCSS as its default parse mode, we map
+            // the "scss" and "sass" values for the lang attribute to the right configs here.
+            // other preprocessors should work out of the box, no loader config like this nessessary.
             'scss': 'vue-style-loader!css-loader!sass-loader',
-            'sass': 'vue-style-loader!css-loader!sass-loader?indentedSytax'
+            'sass': 'vue-style-loader!css-loader!sass-loader?indentedSyntax'
           }
-          // vue-loader options go here
+          // other vue-loader options go here
         }
       },
       {


### PR DESCRIPTION
This preconfigured loader options for "sass" and "scss" in the webpack config so that the corresponding `lang=` attribute values in .vue files work as people would expect.

This also means that the webpack template and this template now behave the same in this refgard.