### PR TITLE
Replace existing Babel presets/plugins by the `babel-preset-env` preset

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,10 @@
 {
   "presets": [
-    ["es2015", { "modules": false }]
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions", "safari >= 7"]
+      },
+      "modules": false
+    }]
   ]
 }

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",
-    "babel-preset-es2015": "^6.0.0",
+    "babel-preset-env": "^1.0.0",
     "cross-env": "^3.0.0",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",


### PR DESCRIPTION
I suggest this change because this preset will allow the future developments with more flexibility.

Also, new projects will have access to the latest Babel features without any additional packages and automatically adapted to the targeted browsers.