### PR TITLE
remove default option --inline from package.json

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "author": "{{ author }}",
   "private": true,
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --inline --hot",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {


### PR DESCRIPTION
Webpack 2 default is to served with inline mode enabled.
https://webpack.js.org/configuration/dev-server/#devserver-inline-cli-only