### PR TITLE
Updates, fixes, simplifications

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,0 @@
-{
-  "presets": [
-    ["es2015", { "modules": false }]
-  ]
-}

--- a/template/package.json
+++ b/template/package.json
@@ -21,7 +21,7 @@
     "babel-loader": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "cross-env": "^3.0.0",
-    "css-loader": "^0.25.0",
+    "css-loader": "^0.26.0",
     "file-loader": "^0.10.1",
     {{#sass}}
     "node-sass": "^4.5.0",

--- a/template/package.json
+++ b/template/package.json
@@ -27,7 +27,7 @@
     "node-sass": "^4.5.0",
     "sass-loader": "^5.0.1",
     {{/sass}}
-    "vue-loader": "^10.0.0",
+    "vue-loader": "^11.0.0",
     "vue-template-compiler": "^2.1.0",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.2.0"

--- a/template/package.json
+++ b/template/package.json
@@ -22,7 +22,7 @@
     "babel-preset-es2015": "^6.0.0",
     "cross-env": "^3.0.0",
     "css-loader": "^0.25.0",
-    "file-loader": "^0.9.0",
+    "file-loader": "^0.10.1",
     {{#sass}}
     "node-sass": "^4.5.0",
     "sass-loader": "^5.0.1",

--- a/template/package.json
+++ b/template/package.json
@@ -9,7 +9,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "vue": "^2.1.0"
+    "vue": "^2.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -11,6 +11,11 @@
   "dependencies": {
     "vue": "^2.2.0"
   },
+  "babel": {
+    "presets": [
+      ["es2015", { "modules": false }]
+    ]
+  },
   "devDependencies": {
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -9,7 +9,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "vue": "^2.2.0"
+    "vue": "^2.2.1"
   },
   "babel": {
     "presets": [
@@ -28,7 +28,7 @@
     "sass-loader": "^5.0.1",
     {{/sass}}
     "vue-loader": "^11.0.0",
-    "vue-template-compiler": "^2.1.0",
+    "vue-template-compiler": "^2.2.1",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.2.0"
   }

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -40,11 +40,6 @@ module.exports = {
       }
     ]
   },
-  resolve: {
-    alias: {
-      'vue$': 'vue/dist/vue.common.js'
-    }
-  },
   devServer: {
     historyApiFallback: true,
     noInfo: true


### PR DESCRIPTION
- fixes `DeprecationWarning` from #74 
- uses vue 2.2.x so it removes `alias` from webpack config
- moves .bablerc settings into `package.json`

I know these are all not related really, but I thought it would be faster to just combine them. (especially moving `.babelrc` into `package.json`, I just find it much cleaner that way).