### PR TITLE
Disable ES2015 module transform via pass down.

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,7 @@
 {
   "presets": [
-    ["latest", { "modules": false }]
+    ["latest", {
+      "es2015": { "modules": false }
+    }]
   ]
 }


### PR DESCRIPTION
The `"modules": false` option needs to be passed down to the `es2015` preset.
See https://babeljs.io/docs/plugins/preset-latest/#usagees2015