### PR TITLE
Webpack production config

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -5,8 +5,8 @@
   "author": "{{ author }}",
   "private": true,
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
-    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
+    "dev": "webpack-dev-server --open --hot",
+    "build": "webpack -p --progress --hide-modules"
   },
   "dependencies": {
     "vue": "^2.2.1"
@@ -15,7 +15,6 @@
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",
     "babel-preset-latest": "^6.0.0",
-    "cross-env": "^3.0.0",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
     {{#sass}}

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -55,15 +55,10 @@ module.exports = {
   devtool: '#eval-source-map'
 }
 
-if (process.env.NODE_ENV === 'production') {
+if (process.argv.indexOf('-p') !== -1) {
   module.exports.devtool = '#source-map'
   // http://vue-loader.vuejs.org/en/workflow/production.html
   module.exports.plugins = (module.exports.plugins || []).concat([
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"production"'
-      }
-    }),
     new webpack.optimize.UglifyJsPlugin({
       sourceMap: true,
       compress: {


### PR DESCRIPTION
``` bash
// shortcut for --optimize-minimize --define process.env.NODE_ENV="production"
$ webpack -p
```
Manual definition of process.env.NODE_ENV is not really necessary.