### PR TITLE
Use runtime build in production.

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -57,6 +57,12 @@ module.exports = {
 
 if (process.env.NODE_ENV === 'production') {
   module.exports.devtool = '#source-map'
+  module.exports.resolve = {
+    alias: {
+      'vue$': 'vue/dist/vue.runtime.esm.js'
+    }
+  }
+
   // http://vue-loader.vuejs.org/en/workflow/production.html
   module.exports.plugins = (module.exports.plugins || []).concat([
     new webpack.DefinePlugin({

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -52,7 +52,6 @@ module.exports = {
 
 if (process.env.NODE_ENV === 'production') {
   module.exports.devtool = '#source-map'
-
   // http://vue-loader.vuejs.org/en/workflow/production.html
   module.exports.plugins = (module.exports.plugins || []).concat([
     new webpack.DefinePlugin({

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -40,11 +40,6 @@ module.exports = {
       }
     ]
   },
-  resolve: {
-    alias: {
-      'vue$': 'vue/dist/vue.esm.js'
-    }
-  },
   devServer: {
     historyApiFallback: true,
     noInfo: true
@@ -57,11 +52,6 @@ module.exports = {
 
 if (process.env.NODE_ENV === 'production') {
   module.exports.devtool = '#source-map'
-  module.exports.resolve = {
-    alias: {
-      'vue$': 'vue/dist/vue.runtime.esm.js'
-    }
-  }
 
   // http://vue-loader.vuejs.org/en/workflow/production.html
   module.exports.plugins = (module.exports.plugins || []).concat([


### PR DESCRIPTION
Use `vue.runtime.esm.js` for production build.

Was getting a runtime of 30K+. This change fixes a problem, but I'm far from sure if it's correct solution or if this needs to be fixed on a different level/package. I think same issue is happening on [webpack template](https://github.com/vuejs-templates/webpack) too.

I actually discovered this playing with [rails/webpacker](https://github.com/rails/webpacker) (cc @gauravtiwari).