### PR TITLE
Revert "Remove extra character"

### DIFF
--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <img src="./assets/logo.png">
-    <h1>{{ msg }}</h1>
+    <h1>\{{ msg }}</h1>
     <h2>Essential Links</h2>
     <ul>
       <li><a href="https://vuejs.org" target="_blank">Core Docs</a></li>


### PR DESCRIPTION
The escape character prevented metalsmith from removing `{{ msg }}` from the template. In a newly generated project using this template, the resulting App.vue file does not have `{{ msg }}` between the `h1` tags.

This reverts commit f7e0de88667be9aef74a16acf04e62cfcc475ba7.