### PR TITLE
@ now points to the src folder

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -42,7 +42,8 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'vue$': 'vue/dist/vue.esm.js'
+      'vue$': 'vue/dist/vue.esm.js',
+      '@': path.resolve(__dirname, './src')
     }
   },
   devServer: {


### PR DESCRIPTION
in js now you can use 
`let image = require("@/assets/image.png")` instead of `let image = require("../../assets/image.png")` 
or
`import someComponent from "@/components/Header.vue"` instead of `import someComponent from "./components/Header.vue`
or
`import someComponent from "@/components/Header.vue"` instead of `import someComponent from "../../components/Header.vue`