### PR TITLE
Remove period from run dev command

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -21,5 +21,5 @@
        "default": false
     }
   },
-  "completeMessage": "{{#inPlace}}To get started:\n\n  npm install\n  npm run dev.{{else}}To get started:\n\n  cd {{destDirName}}\n  npm install\n  npm run dev.{{/inPlace}}"
+  "completeMessage": "{{#inPlace}}To get started:\n\n  npm install\n  npm run dev{{else}}To get started:\n\n  cd {{destDirName}}\n  npm install\n  npm run dev{{/inPlace}}"
 }


### PR DESCRIPTION
The `completeMessage` commands already appear on different lines. When a `.` is added, it looks like part of the `npm run dev` command, which can cause confusion for new users.