### PR TITLE
Upgrade allowed libraries to the latest stable version.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "vue": "^2.5.11"
+    "vue": "^2.5.16"
   },
   "browserslist": [
     "> 1%",
@@ -19,18 +19,18 @@
   ],
   "devDependencies": {
     "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
-    "babel-preset-env": "^1.6.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-3": "^6.24.1",
-    "cross-env": "^5.0.5",
-    "css-loader": "^0.28.7",
-    "file-loader": "^1.1.4",
+    "cross-env": "^5.1.4",
+    "css-loader": "^0.28.11",
+    "file-loader": "^1.1.11",
     {{#sass}}
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
     {{/sass}}
-    "vue-loader": "^13.0.5",
-    "vue-template-compiler": "^2.4.4",
+    "vue-loader": "^14.2.2",
+    "vue-template-compiler": "^2.5.16",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   }


### PR DESCRIPTION
The origin of this PR is due to some users encountering problems with VuePress integration when using `webpack-simple`, see: https://github.com/vuejs/vuepress/issues/69

This PR is to upgrade all the allowed libraries to the latest stable version.

- Not upgrade webpack to 4 is because webpack4 still have some bugs with webpack-dev-server, see: https://github.com/webpack/webpack/issues/6917
- Not upgrade babel to 7 is because it's still in beta stage.

Local test successfully.